### PR TITLE
since minsdk is 16, we need to disable android neon which is enabled by default

### DIFF
--- a/AXrLottie/build.gradle
+++ b/AXrLottie/build.gradle
@@ -13,6 +13,7 @@ android {
         consumerProguardFiles "consumer-rules.pro"
         externalNativeBuild {
             cmake {
+                arguments "-DANDROID_ARM_NEON=OFF"
                 cppFlags "-std=c++14"
             }
         }


### PR DESCRIPTION
https://github.com/Samsung/rlottie/issues/462

Right now it is enabled by [default](https://android-developers.googleblog.com/2019/10/introducing-ndk-r21-our-first-long-term.html)

So, I added cmake flag to disable it since minsdk is 16 right now and it neon requires 23+. Without it build fails with:

```
[39/41] Building CXX object CMakeFiles/rlottie.dir/src/lottie/lottieparser.cpp.
[40/41] Linking CXX shared library /Users/liminiens/Documents/Code/AXrLottie/AXrLottie/build/intermediates/cmake/debug/obj/armeabi-v7a/librlottie.so
FAILED: /Users/liminiens/Documents/Code/AXrLottie/AXrLottie/build/intermediates/cmake/debug/obj/armeabi-v7a/librlottie.so 
: && /Users/liminiens/Library/Android/sdk/ndk/21.0.6113669/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ --target=armv7-none-linux-androideabi16 --gcc-toolchain=/Users/liminiens/Library/Android/sdk/ndk/21.0.6113669/toolchains/llvm/prebuilt/darwin-x86_64 --sysroot=/Users/liminiens/Library/Android/sdk/ndk/21.0.6113669/toolchains/llvm/prebuilt/darwin-x86_64/sysroot -fPIC -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security  -std=c++14 -O0 -fno-limit-debug-info  -Wl,--exclude-libs,libgcc_real.a -Wl,--exclude-libs,libatomic.a -static-libstdc++ -Wl,--build-id -Wl,--fatal-warnings -Wl,--exclude-libs,libunwind.a -Wl,--no-undefined -Qunused-arguments -shared -Wl,-soname,librlottie.so -o /Users/liminiens/Documents/Code/AXrLottie/AXrLottie/build/intermediates/cmake/debug/obj/armeabi-v7a/librlottie.so CMakeFiles/rlottie.dir/src/vector/freetype/v_ft_math.cpp.o CMakeFiles/rlottie.dir/src/vector/freetype/v_ft_raster.cpp.o CMakeFiles/rlottie.dir/src/vector/freetype/v_ft_stroker.cpp.o CMakeFiles/rlottie.dir/src/vector/vrect.cpp.o CMakeFiles/rlottie.dir/src/vector/vdasher.cpp.o CMakeFiles/rlottie.dir/src/vector/vbrush.cpp.o CMakeFiles/rlottie.dir/src/vector/vbitmap.cpp.o CMakeFiles/rlottie.dir/src/vector/vpainter.cpp.o CMakeFiles/rlottie.dir/src/vector/vdrawhelper_common.cpp.o CMakeFiles/rlottie.dir/src/vector/vdrawhelper.cpp.o CMakeFiles/rlottie.dir/src/vector/vdrawhelper_sse2.cpp.o CMakeFiles/rlottie.dir/src/vector/vdrawhelper_neon.cpp.o CMakeFiles/rlottie.dir/src/vector/vrle.cpp.o CMakeFiles/rlottie.dir/src/vector/vpath.cpp.o CMakeFiles/rlottie.dir/src/vector/vpathmesure.cpp.o CMakeFiles/rlottie.dir/src/vector/vmatrix.cpp.o CMakeFiles/rlottie.dir/src/vector/velapsedtimer.cpp.o CMakeFiles/rlottie.dir/src/vector/vdebug.cpp.o CMakeFiles/rlottie.dir/src/vector/vinterpolator.cpp.o CMakeFiles/rlottie.dir/src/vector/vbezier.cpp.o CMakeFiles/rlottie.dir/src/vector/vraster.cpp.o CMakeFiles/rlottie.dir/src/vector/vdrawable.cpp.o CMakeFiles/rlottie.dir/src/vector/vimageloader.cpp.o CMakeFiles/rlottie.dir/src/vector/varenaalloc.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieitem.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieitem_capi.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieloader.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottiemodel.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieproxymodel.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieparser.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottieanimation.cpp.o CMakeFiles/rlottie.dir/src/lottie/lottiekeypath.cpp.o  -Wl,--version-script=/Users/liminiens/Documents/Code/AXrLottie/AXrLottie/src/main/cpp/rlottie.expmap -ldl -Wl,--no-undefined -latomic -lm && :
/Users/liminiens/Documents/Code/AXrLottie/AXrLottie/src/main/cpp/src/vector/vdrawhelper_neon.cpp:17: error: undefined reference to 'pixman_composite_src_n_8888_asm_neon'
/Users/liminiens/Documents/Code/AXrLottie/AXrLottie/src/main/cpp/src/vector/vdrawhelper_neon.cpp:26: error: undefined reference to 'pixman_composite_over_n_8888_asm_neon'
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.

> Task :AXrLottie:externalNativeBuildDebug FAILED
```
