### PR TITLE
`async` parameter is not pass through correctly

### DIFF
--- a/AXrLottie/src/main/java/com/aghajari/rlottie/AXrLottieDrawable.java
+++ b/AXrLottie/src/main/java/com/aghajari/rlottie/AXrLottieDrawable.java
@@ -864,7 +864,7 @@ public class AXrLottieDrawable extends BitmapDrawable implements Animatable {
     }
 
     public void setCurrentFrame(int frame, boolean async) {
-        setCurrentFrame(frame, true, false);
+        setCurrentFrame(frame, async, false);
     }
 
     public void setCurrentFrame(int frame, boolean async, boolean resetFrame) {


### PR DESCRIPTION
While using `setCurrentFrame`, one of the override functions doesn't seem to pass the `async` parameter through correctly. This PR fixes that. 